### PR TITLE
Use raf in start method as well.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,7 @@ Game.prototype.start = function () {
   this.emit('start')
   this.dt = 0
   this.accumulator = 0.0
-  var time = this.timestamp()
-  this.frame(time)
+  raf(this.frame.bind(this))
 }
 
 Game.prototype.frame = function (time) {


### PR DESCRIPTION
I found a bug in the loop itself. Sometimes it only did one second of "update"+"draw" calls and then only "draw" calls. I think it has something to do with the timestamps. If you use raf in the start (as is done in the raf examples as well), then the timestamps are all managed by raf and the problem seems to be solved.
